### PR TITLE
Add un mark task feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -46,7 +46,7 @@ public class MarkTaskCommand extends Command {
         MarkTaskDescriptor configureMarkedTask = new MarkTaskDescriptor();
         configureMarkedTask.setStatus(true);
         Task markedTask = createMarkedTask(taskToMark, configureMarkedTask);
-        model.markTask(markedTask, targetIndex);
+        model.setTask(markedTask, targetIndex);
 
         model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
         return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, markedTask));

--- a/src/main/java/seedu/address/logic/commands/UnMarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnMarkTaskCommand.java
@@ -1,0 +1,170 @@
+package seedu.address.logic.commands;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Task;
+
+/**
+ * Marks a task identified by its displayed index in the GUI as completed.
+ */
+public class UnMarkTaskCommand extends Command {
+    public static final String COMMAND_WORD = "unmark";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Un-marks the task identified by the index number used in the displayed task list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+    public static final String MESSAGE_UNMARK_TASK_SUCCESS = "Marked Task as Not Done: %1$s";
+    private final Index targetIndex;
+
+    public UnMarkTaskCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> lastShownTaskList = model.getFilteredTaskList();
+
+        if (targetIndex.getZeroBased() >= lastShownTaskList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToUnMark = lastShownTaskList.get(targetIndex.getZeroBased());
+        UnMarkTaskDescriptor configureUnMarkedTask = new UnMarkTaskDescriptor();
+        configureUnMarkedTask.setStatus(false);
+        Task unMarkedTask = createUnMarkedTask(taskToUnMark, configureUnMarkedTask);
+        model.unMarkTask(unMarkedTask, targetIndex);
+
+        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
+        return new CommandResult(String.format(MESSAGE_UNMARK_TASK_SUCCESS, unMarkedTask));
+    }
+
+    /**
+     * Creates and returns a {@code Task} with the details of {@code taskToEdit}
+     * edited with {@code editUnMarkTaskDescriptor}.
+     */
+    private static Task createUnMarkedTask(
+            Task taskToUnMark, UnMarkTaskCommand.UnMarkTaskDescriptor unMarkTaskDescriptor) {
+        assert taskToUnMark != null;
+
+        String updatedTitle = unMarkTaskDescriptor.getTitle().orElse(taskToUnMark.getTitle());
+        String updatedDeadline = unMarkTaskDescriptor.getDeadline().orElse(taskToUnMark.getDeadline());
+        boolean updatedStatus = unMarkTaskDescriptor.getStatus().orElse(taskToUnMark.getStatus());
+        Set<Tag> updatedTags = unMarkTaskDescriptor.getTags().orElse(taskToUnMark.getTags());
+
+        return new Task(updatedTitle, updatedDeadline, updatedStatus, updatedTags);
+    }
+
+    /**
+     * Stores the details to edit the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class UnMarkTaskDescriptor {
+        private String title;
+        private String deadline;
+        private boolean status;
+        private Set<Tag> tags;
+
+        public UnMarkTaskDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public UnMarkTaskDescriptor(UnMarkTaskCommand.UnMarkTaskDescriptor toCopy) {
+            setTitle(toCopy.title);
+            setDeadline(toCopy.deadline);
+            setStatus(toCopy.status);
+            setTags(toCopy.tags);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(title, deadline, status, tags);
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public Optional<String> getTitle() {
+            return Optional.ofNullable(title);
+        }
+
+        public void setDeadline(String deadline) {
+            this.deadline = deadline;
+        }
+
+        public Optional<String> getDeadline() {
+            return Optional.ofNullable(deadline);
+        }
+
+        public void setStatus(boolean status) {
+            this.status = status;
+        }
+
+        public Optional<Boolean> getStatus() {
+            return Optional.ofNullable(status);
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof UnMarkTaskCommand.UnMarkTaskDescriptor)) {
+                return false;
+            }
+
+            // state check
+            UnMarkTaskCommand.UnMarkTaskDescriptor e = (UnMarkTaskCommand.UnMarkTaskDescriptor) other;
+
+            return getTitle().equals(e.getTitle())
+                    && getDeadline().equals(e.getDeadline())
+                    && getStatus().equals(e.getStatus())
+                    && getTags().equals(e.getTags());
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnMarkTaskCommand
+                && targetIndex.equals(((UnMarkTaskCommand) other).targetIndex));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnMarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnMarkTaskCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Task;
 
 /**
- * Marks a task identified by its displayed index in the GUI as completed.
+ * Un marks a task identified by its displayed index in the GUI as completed.
  */
 public class UnMarkTaskCommand extends Command {
     public static final String COMMAND_WORD = "unmark";
@@ -46,7 +46,7 @@ public class UnMarkTaskCommand extends Command {
         UnMarkTaskDescriptor configureUnMarkedTask = new UnMarkTaskDescriptor();
         configureUnMarkedTask.setStatus(false);
         Task unMarkedTask = createUnMarkedTask(taskToUnMark, configureUnMarkedTask);
-        model.unMarkTask(unMarkedTask, targetIndex);
+        model.setTask(unMarkedTask, targetIndex);
 
         model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
         return new CommandResult(String.format(MESSAGE_UNMARK_TASK_SUCCESS, unMarkedTask));

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
+import seedu.address.logic.commands.UnMarkTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -71,6 +72,9 @@ public class AddressBookParser {
 
         case MarkTaskCommand.COMMAND_WORD:
             return new MarkTaskCommandParser().parse(arguments);
+
+        case UnMarkTaskCommand.COMMAND_WORD:
+            return new UnMarkTaskCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
@@ -7,13 +7,13 @@ import seedu.address.logic.commands.MarkTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object
+ * Parses input arguments and creates a new MarkTaskCommand object
  */
 public class MarkTaskCommandParser implements Parser<MarkTaskCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the DeleteCommand
-     * and returns a DeleteCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the MarkTaskCommand
+     * and returns a MarkTaskCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public MarkTaskCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/UnMarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnMarkTaskCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnMarkTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UnMarkTaskCommand object
+ */
+public class UnMarkTaskCommandParser implements Parser<UnMarkTaskCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnMarkTaskCommand
+     * and returns a UnMarkTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnMarkTaskCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new UnMarkTaskCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkTaskCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}
+

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -72,16 +72,10 @@ public interface Model {
     void deletePerson(Person target);
 
     /**
-     * Marks the given task as completed.
-     * The task must exist in the task list.
+     * Replaces the given task {@code target} with {@code editedTask}.
+     * {@code task} must exist in the task list.
      */
-    void markTask(Task task, Index targetIndex);
-
-    /**
-     * Unmarks the given task as not done.
-     * The task must exist in the task list.
-     */
-    void unMarkTask(Task task, Index targetIndex);
+    void setTask(Task task, Index targetIndex);
 
     /**
      * Adds the given person.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -78,6 +78,12 @@ public interface Model {
     void markTask(Task task, Index targetIndex);
 
     /**
+     * Unmarks the given task as not done.
+     * The task must exist in the task list.
+     */
+    void unMarkTask(Task task, Index targetIndex);
+
+    /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -83,13 +83,9 @@ public class ModelManager implements Model {
     }
 
     //=========== TaskList ===================================================================================
-    @Override
-    public void markTask(Task task, Index targetIndex) {
-        taskList.setTask(task, targetIndex);
-    }
 
     @Override
-    public void unMarkTask(Task task, Index targetIndex) {
+    public void setTask(Task task, Index targetIndex) {
         taskList.setTask(task, targetIndex);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -89,6 +89,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void unMarkTask(Task task, Index targetIndex) {
+        taskList.setTask(task, targetIndex);
+    }
+
+    @Override
     public ReadOnlyTaskList getTaskList() {
         return taskList;
     }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -57,7 +57,6 @@ public class StorageManager implements Storage {
 
     @Override
     public Optional<ReadOnlyTaskList> readTaskList() throws DataConversionException, IOException {
-        // TODO: readTaskList(Path filePath)
         return readTaskList(taskStorage.getTaskListFilePath());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -145,7 +145,12 @@ public class AddCommandTest {
 
         @Override
         public void markTask(Task task, Index targetIndex) {
+            throw new AssertionError("This method should not be called.");
+        }
 
+        @Override
+        public void unMarkTask(Task task, Index targetIndex) {
+            throw new AssertionError("This method should not be called.");
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -144,12 +144,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void markTask(Task task, Index targetIndex) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void unMarkTask(Task task, Index targetIndex) {
+        public void setTask(Task task, Index targetIndex) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/MarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkTaskCommandTest.java
@@ -30,7 +30,7 @@ public class MarkTaskCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new UserPrefs(), new TaskList(model.getTaskList()));
-        expectedModel.markTask(model.getFilteredTaskList().get(0), INDEX_FIRST_PERSON);
+        expectedModel.setTask(model.getFilteredTaskList().get(0), INDEX_FIRST_PERSON);
 
         assertCommandSuccess(markTaskCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/UnMarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnMarkTaskCommandTest.java
@@ -30,7 +30,7 @@ public class UnMarkTaskCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new UserPrefs(), new TaskList(model.getTaskList()));
-        expectedModel.unMarkTask(model.getFilteredTaskList().get(0), INDEX_FIRST_PERSON);
+        expectedModel.setTask(model.getFilteredTaskList().get(0), INDEX_FIRST_PERSON);
 
         assertCommandSuccess(unMarkTaskCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/UnMarkTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnMarkTaskCommandTest.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.TaskList;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.TaskBuilder;
+
+public class UnMarkTaskCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), getTypicalTaskList());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Task unMarkedTask = new TaskBuilder().withStatus(false).build();
+        UnMarkTaskCommand unMarkTaskCommand = new UnMarkTaskCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(UnMarkTaskCommand.MESSAGE_UNMARK_TASK_SUCCESS, unMarkedTask);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs(), new TaskList(model.getTaskList()));
+        expectedModel.unMarkTask(model.getFilteredTaskList().get(0), INDEX_FIRST_PERSON);
+
+        assertCommandSuccess(unMarkTaskCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        UnMarkTaskCommand unMarkTaskCommand = new UnMarkTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(unMarkTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
+import seedu.address.logic.commands.UnMarkTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -92,6 +93,11 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_mark() throws Exception {
         assertTrue(parser.parseCommand(MarkTaskCommand.COMMAND_WORD + " 1") instanceof MarkTaskCommand);
+    }
+
+    @Test
+    public void parseCommand_unmark() throws Exception {
+        assertTrue(parser.parseCommand(UnMarkTaskCommand.COMMAND_WORD + " 1") instanceof UnMarkTaskCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/UnMarkTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnMarkTaskCommandParserTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UnMarkTaskCommand;
+
+public class UnMarkTaskCommandParserTest {
+    private UnMarkTaskCommandParser parser = new UnMarkTaskCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUnMarkTaskCommand() {
+        assertParseSuccess(parser, "1", new UnMarkTaskCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkTaskCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Add UnMarkTaskCommand and UnMarkTaskCommandParser and their test counterparts

Includes above average coverage of tests

# Usage
- `unmark <index>`

![image](https://user-images.githubusercontent.com/56034480/194737429-d291bd81-0c51-4435-9d01-d63deae8ad71.png)
