### PR TITLE
Add commands to list all storage types

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAllCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
 public class ListAllCommand extends Command {
     public static final String COMMAND_WORD = "listAll";
 
-    public static final String MESSAGE_SUCCESS = "Listed all items in Salesy!";
+    public static final String MESSAGE_SUCCESS = "Listed all entities in Salesy!";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/ListAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAllCommand.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all items in Salesy.
+ */
+public class ListAllCommand extends Command {
+    public static final String COMMAND_WORD = "listAll";
+
+    public static final String MESSAGE_SUCCESS = "Listed all items in Salesy!";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTaskList(Model.PREDICATE_SHOW_ALL_TASKS);
+        model.updateFilteredSupplyItemList(Model.PREDICATE_SHOW_ALL_SUPPLY_ITEMS);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListInventoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListInventoryCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SUPPLY_ITEMS;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all supply items in the inventory.
+ */
+public class ListInventoryCommand extends Command {
+    public static final String COMMAND_WORD = "listInventory";
+
+    public static final String MESSAGE_SUCCESS = "List all supply items in inventory";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredSupplyItemList(PREDICATE_SHOW_ALL_SUPPLY_ITEMS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListInventoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListInventoryCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
 public class ListInventoryCommand extends Command {
     public static final String COMMAND_WORD = "listInventory";
 
-    public static final String MESSAGE_SUCCESS = "List all supply items in inventory";
+    public static final String MESSAGE_SUCCESS = "List all items in inventory";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/ListSupplierCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListSupplierCommand.java
@@ -8,9 +8,9 @@ import seedu.address.model.Model;
 /**
  * Lists all suppliers in the address book to the user.
  */
-public class ListCommand extends Command {
+public class ListSupplierCommand extends Command {
 
-    public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_WORD = "listSuppliers";
 
     public static final String MESSAGE_SUCCESS = "Listed all suppliers";
 

--- a/src/main/java/seedu/address/logic/commands/ListTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTaskCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all tasks in the task list to the user.
+ */
+public class ListTaskCommand extends Command {
+    public static final String COMMAND_WORD = "listTasks";
+
+    public static final String MESSAGE_SUCCESS = "Listed all tasks";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,7 +16,10 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListAllCommand;
+import seedu.address.logic.commands.ListInventoryCommand;
+import seedu.address.logic.commands.ListSupplierCommand;
+import seedu.address.logic.commands.ListTaskCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
 import seedu.address.logic.commands.UnMarkTaskCommand;
 import seedu.address.logic.commands.UpdateTaskCommand;
@@ -64,8 +67,17 @@ public class AddressBookParser {
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+        case ListAllCommand.COMMAND_WORD:
+            return new ListAllCommand();
+
+        case ListInventoryCommand.COMMAND_WORD:
+            return new ListInventoryCommand();
+
+        case ListSupplierCommand.COMMAND_WORD:
+            return new ListSupplierCommand();
+
+        case ListTaskCommand.COMMAND_WORD:
+            return new ListTaskCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListSupplierCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Inventory;
@@ -72,8 +72,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        String listCommand = ListSupplierCommand.COMMAND_WORD;
+        assertCommandSuccess(listCommand, ListSupplierCommand.MESSAGE_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.item.SupplyItem;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
@@ -158,5 +159,18 @@ public class CommandTestUtil {
         model.updateFilteredTaskList(t -> t.equals(task));
 
         assertEquals(1, model.getFilteredTaskList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the supply item at the given {@code targetIndex} in the
+     * {@code model}'s inventory.
+     */
+    public static void showSupplyItemAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredSupplyItemList().size());
+
+        SupplyItem supplyItem = model.getFilteredSupplyItemList().get(targetIndex.getZeroBased());
+        model.updateFilteredSupplyItemList(i -> i.equals(supplyItem));
+
+        assertEquals(1, model.getFilteredSupplyItemList().size());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListInventoryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListInventoryCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showSupplyItemAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_SUPPLY_ITEM;
+import static seedu.address.testutil.TypicalSupplyItems.getTypicalInventory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.TaskList;
+import seedu.address.model.UserPrefs;
+
+public class ListInventoryCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(new AddressBook(), new UserPrefs(),
+                new TaskList(), getTypicalInventory());
+        expectedModel = new ModelManager(new AddressBook(), new UserPrefs(),
+                new TaskList(), model.getInventory());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListInventoryCommand(), model, ListInventoryCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showSupplyItemAtIndex(model, INDEX_FIRST_SUPPLY_ITEM);
+        assertCommandSuccess(new ListInventoryCommand(), model, ListInventoryCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ListSupplierCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListSupplierCommandTest.java
@@ -17,7 +17,7 @@ import seedu.address.model.UserPrefs;
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
  */
-public class ListCommandTest {
+public class ListSupplierCommandTest {
 
     private Model model;
     private Model expectedModel;
@@ -32,12 +32,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListSupplierCommand(), model, ListSupplierCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListSupplierCommand(), model, ListSupplierCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListTaskCommandTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showTaskAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Inventory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListTaskCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(new AddressBook(), new UserPrefs(),
+                getTypicalTaskList(), new Inventory());
+        expectedModel = new ModelManager(new AddressBook(), new UserPrefs(),
+                model.getTaskList(), new Inventory());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListTaskCommand(), model, ListTaskCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+        assertCommandSuccess(new ListTaskCommand(), model, ListTaskCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -23,7 +23,7 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListSupplierCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
 import seedu.address.logic.commands.UnMarkTaskCommand;
 import seedu.address.logic.commands.UpdateTaskCommand;
@@ -89,8 +89,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListSupplierCommand.COMMAND_WORD) instanceof ListSupplierCommand);
+        assertTrue(parser.parseCommand(ListSupplierCommand.COMMAND_WORD + " 3") instanceof ListSupplierCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,6 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_SUPPLY_ITEM = Index.fromOneBased(1);
+    public static final Index INDEX_FIRST_TASK = Index.fromOneBased(1);
 }


### PR DESCRIPTION
Adequate unit tests to cover the new commands

# Commands 
- `listAll` -> List everything in Salesy
- `listSuppliers` -> List all suppliers
- `listTasks`-> List all tasls
- `listInventory` -> List all inventory supply items