### PR TITLE
Implement edit SupplyItem functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -19,6 +19,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.item.SupplyItem;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Item;
@@ -78,6 +79,7 @@ public class EditCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
+        // editing supplier details
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
@@ -85,8 +87,16 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        // editing supplier's SupplyItem details
+        boolean inventoryContainsSupplier = model.hasSupplyItemSuppliedBy(editedPerson);
+        if (inventoryContainsSupplier) {
+            CommandResult editItemResult =
+                    new EditItemSupplierCommand(editedPerson).execute(model);
+        }
+
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditItemSupplierCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditItemSupplierCommand.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SUPPLY_ITEMS;
+
+import static java.util.Objects.requireNonNull;
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.item.SupplyItem;
+import seedu.address.model.person.Person;
+
+/**
+ * Edits the details of an existing supply item in the inventory.
+ * Can only be executed through {@code EditCommand}.
+ */
+public class EditItemSupplierCommand extends Command {
+
+    private final Person editedSupplier;
+
+    public static final String MESSAGE_ITEM_NOTFOUND = "The specified item could not be found";
+    public static final String MESSAGE_DUPLICATE_ITEM = "This supply item already exists in the inventory.";
+    public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Edited Item.";
+
+    /**
+     * @param editedSupplier supplier details to edit the item with
+     */
+    public EditItemSupplierCommand(Person editedSupplier) {
+        requireNonNull(editedSupplier);
+
+        this.editedSupplier = editedSupplier;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        Optional<SupplyItem> supplyItemOptional = model.supplyItemSuppliedBy(editedSupplier);
+
+        SupplyItem supplyItemToEdit =
+                supplyItemOptional.orElseThrow(() -> new CommandException(MESSAGE_ITEM_NOTFOUND));
+        SupplyItem editedSupplyItem = new SupplyItem(
+                editedSupplier.getItem().toString(),
+                supplyItemToEdit.getCurrentStock(),
+                supplyItemToEdit.getMinStock(),
+                editedSupplier,
+                supplyItemToEdit.getTags());
+        Index supplyItemToEditIndex =
+                Index.fromZeroBased(model.getFilteredSupplyItemList().indexOf(supplyItemToEdit));
+
+        if (model.hasSupplyItemExcluding(editedSupplyItem, supplyItemToEdit)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ITEM);
+        }
+
+        model.setSupplyItem(editedSupplyItem, supplyItemToEditIndex);
+        model.updateFilteredSupplyItemList(PREDICATE_SHOW_ALL_SUPPLY_ITEMS);
+
+        return new CommandResult(MESSAGE_EDIT_ITEM_SUCCESS);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Inventory.java
+++ b/src/main/java/seedu/address/model/Inventory.java
@@ -3,11 +3,13 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.item.SupplyItem;
+import seedu.address.model.person.Person;
 
 /**
  * Wraps all data at the Inventory level.
@@ -67,6 +69,37 @@ public class Inventory implements ReadOnlyInventory {
     public boolean hasSupplyItem(SupplyItem item) {
         requireNonNull(item);
         return this.supplyItems.contains(item);
+    }
+
+    /**
+     * Checks whether {@item} is a duplicate in Inventory excluding {@excludedItem} from the check.
+     */
+    public boolean hasSupplyItemExcluding(SupplyItem item, SupplyItem excludedItem) {
+        requireNonNull(item);
+        requireNonNull(excludedItem);
+        return this.supplyItems.stream()
+                .filter(listItem -> !listItem.equals(excludedItem))
+                .anyMatch(item::isSameItem);
+    }
+
+    /**
+     * Returns the SupplyItem that is supplied by {@code supplier}, if any.
+     * @param supplier the supplier to check for supply items supplied by
+     * @return an Optional encapsulating the SupplyItem supplied by {@code supplier}
+     */
+    public Optional<SupplyItem> supplyItemSuppliedBy(Person supplier) {
+        requireNonNull(supplier);
+        return this.supplyItems.stream()
+                .filter(listItem -> listItem.getSupplier().isSamePerson(supplier))
+                .findFirst();
+    }
+
+    /**
+     * Checks whether {@supplier} is a supplier for any SupplyItem in the inventory.
+     */
+    public boolean hasSupplyItemSuppliedBy(Person supplier) {
+        return this.supplyItems.stream()
+                .anyMatch(listItem -> listItem.getSupplier().isSamePerson(supplier));
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -9,6 +10,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.model.item.SupplyItem;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * The API of the Model component.
@@ -93,6 +96,21 @@ public interface Model {
      * Returns true if there is a duplicated supply item in the inventory.
      */
     boolean hasSupplyItem(SupplyItem item);
+
+    /**
+     * Returns true if there is a duplicated supply item in the inventory, ignoring {@code excludedItem}.
+     */
+    boolean hasSupplyItemExcluding(SupplyItem item, SupplyItem excludedItem);
+
+    /**
+     * Returns true if {@supplier} is a supplier for some supply item in the inventory.
+     */
+    boolean hasSupplyItemSuppliedBy(Person supplier);
+
+    /**
+     * Returns the SupplyItem that is supplied by {@code supplier}, if any.
+     */
+    Optional<SupplyItem> supplyItemSuppliedBy(Person supplier);
 
     /**
      * Replaces the given supply item {@code target} with {@code editedSupplyItem}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -98,6 +99,21 @@ public class ModelManager implements Model {
     @Override
     public boolean hasSupplyItem(SupplyItem item) {
         return inventory.hasSupplyItem(item);
+    }
+
+    @Override
+    public boolean hasSupplyItemExcluding(SupplyItem item, SupplyItem excludedItem) {
+        return inventory.hasSupplyItemExcluding(item, excludedItem);
+    }
+
+    @Override
+    public boolean hasSupplyItemSuppliedBy(Person supplier) {
+        return inventory.hasSupplyItemSuppliedBy(supplier);
+    }
+
+    @Override
+    public Optional<SupplyItem> supplyItemSuppliedBy(Person supplier) {
+        return inventory.supplyItemSuppliedBy(supplier);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/item/SupplyItem.java
+++ b/src/main/java/seedu/address/model/item/SupplyItem.java
@@ -77,6 +77,19 @@ public class SupplyItem {
         return tags;
     }
 
+    /**
+     * Returns true if both items have the same name.
+     */
+    public boolean isSameItem(SupplyItem otherItem) {
+        if (otherItem == this) {
+            return true;
+        }
+
+        return otherItem != null
+                && (otherItem.getName().equals(getName())
+                || otherItem.getSupplier().equals(getSupplier()));
+    }
+
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -62,9 +62,9 @@ public class SampleDataUtil {
 
     public static SupplyItem[] getSampleSupplyItems() {
         return new SupplyItem[]{
-            new SupplyItem("Ginger", 5, 2, new Person(new Name("Ya Shu Egg"),
-                new Phone("63450864"), new Price("$1.10"), new Item("Egg"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+            new SupplyItem("Ginger", 5, 2, new Person(new Name("ABC Pte Ltd"),
+                new Phone("67089005"), new Price("$1.00"), new Item("Ginger"),
+                new Address("Blk 30 Geylang Street 29, #06-40"),
                 getTagSet("Supplier")), getTagSet("Item")),
             new SupplyItem("Egg", 5, 2, new Person(new Name("Ya Shu Egg"),
                 new Phone("63450864"), new Price("$1.10"), new Item("Egg"),


### PR DESCRIPTION
Updated function: When a supplier's details are edited through EditCommand, the SupplyItem that it is supplying in Inventory will be updated with relevant details (supplier name, item name, item price)

The details of SupplyItem that are tied to its supplier (supplier name, item name, item price) cannot be directly edited by user - can only be edited by editing the corresponding supplier.

Will convert to official pull request when synced up with addItem functionality, test cases are updated and added, and the whole operation is tested and debugged further