### PR TITLE
Add a command to enable refreshing of stats panel on increment and decrement

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -11,7 +11,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.RefreshStatsCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -44,10 +44,6 @@ public class LogicManager implements Logic {
 
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
-        // Removes log for refreshing Stats panel
-        if (!commandText.equals(RefreshStatsCommand.COMMAND_WORD)) {
-
-        }
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -46,8 +46,9 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         // Removes log for refreshing Stats panel
         if (!commandText.equals(RefreshStatsCommand.COMMAND_WORD)) {
-            logger.info("----------------[USER COMMAND][" + commandText + "]");
+
         }
+        logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.RefreshStatsCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -43,7 +44,10 @@ public class LogicManager implements Logic {
 
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
-        logger.info("----------------[USER COMMAND][" + commandText + "]");
+        // Removes log for refreshing Stats panel
+        if (!commandText.equals(RefreshStatsCommand.COMMAND_WORD)) {
+            logger.info("----------------[USER COMMAND][" + commandText + "]");
+        }
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);

--- a/src/main/java/seedu/address/logic/commands/RefreshStatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RefreshStatsCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.model.Model;
 
 /**
- * Refreshes Stats panel silently. Gives no feedback to user.
+ * Refreshes Stats panel.
  */
 public class RefreshStatsCommand extends Command {
     public static final String COMMAND_WORD = "refreshStats";

--- a/src/main/java/seedu/address/logic/commands/RefreshStatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RefreshStatsCommand.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+
+/**
+ * Refreshes Stats panel silently. Gives no feedback to user.
+ */
+public class RefreshStatsCommand extends Command {
+    public static final String COMMAND_WORD = "refreshStats";
+
+    public static final String MESSAGE_SUCCESS = "silently refresh stats";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RefreshStatsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RefreshStatsCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
 public class RefreshStatsCommand extends Command {
     public static final String COMMAND_WORD = "refreshStats";
 
-    public static final String MESSAGE_SUCCESS = "silently refresh stats";
+    public static final String MESSAGE_SUCCESS = "Updated Inventory!";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.ListInventoryCommand;
 import seedu.address.logic.commands.ListSupplierCommand;
 import seedu.address.logic.commands.ListTaskCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
+import seedu.address.logic.commands.RefreshStatsCommand;
 import seedu.address.logic.commands.UnMarkTaskCommand;
 import seedu.address.logic.commands.UpdateTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -111,6 +112,9 @@ public class AddressBookParser {
 
         case EditStockCommand.COMMAND_WORD:
             return new EditStockCommandParser().parse(arguments);
+
+        case RefreshStatsCommand.COMMAND_WORD:
+            return new RefreshStatsCommand();
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/ui/InventoryPanel.java
+++ b/src/main/java/seedu/address/ui/InventoryPanel.java
@@ -11,7 +11,6 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.RefreshStatsCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.SupplyItem;
@@ -74,14 +73,8 @@ public class InventoryPanel extends UiPart<Region> {
                 setText(null);
             } else {
                 SupplyItemCard updatedCard = new SupplyItemCard(item, getIndex() + 1, increaseHandler.apply(getIndex()),
-                        decreaseHandler.apply(getIndex()), changeIncDecHandler.apply(getIndex()));
+                        decreaseHandler.apply(getIndex()), changeIncDecHandler.apply(getIndex()), executeCommand);
                 setGraphic(updatedCard.getRoot());
-
-                try {
-                    executeCommand.execute(RefreshStatsCommand.COMMAND_WORD);
-                } catch (CommandException | ParseException e) {
-                    logger.warning("Unable to refresh stats panel!");
-                }
             }
         }
     }

--- a/src/main/java/seedu/address/ui/InventoryPanel.java
+++ b/src/main/java/seedu/address/ui/InventoryPanel.java
@@ -10,6 +10,10 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.RefreshStatsCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.SupplyItem;
 
 /**
@@ -18,6 +22,7 @@ import seedu.address.model.item.SupplyItem;
 public class InventoryPanel extends UiPart<Region> {
     private static final String FXML = "InventoryPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(InventoryPanel.class);
+    private final CommandExecutor executeCommand;
 
     private final Function<Integer, Consumer<Integer>> increaseHandler;
     private final Function<Integer, Consumer<Integer>> decreaseHandler;
@@ -32,13 +37,28 @@ public class InventoryPanel extends UiPart<Region> {
     public InventoryPanel(ObservableList<SupplyItem> supplyItemList,
                           Function<Integer, Consumer<Integer>> increaseHandler,
                           Function<Integer, Consumer<Integer>> decreaseHandler,
-                          Function<Integer, Consumer<Integer>> changeIncDecHandler) {
+                          Function<Integer, Consumer<Integer>> changeIncDecHandler,
+                          CommandExecutor executeCommand) {
         super(FXML);
+        this.executeCommand = executeCommand;
         this.increaseHandler = increaseHandler;
         this.decreaseHandler = decreaseHandler;
         this.changeIncDecHandler = changeIncDecHandler;
         inventoryView.setItems(supplyItemList);
         inventoryView.setCellFactory(listView -> new InventoryViewCell());
+    }
+
+    /**
+     * Represents a function that can execute commands.
+     */
+    @FunctionalInterface
+    public interface CommandExecutor {
+        /**
+         * Executes the command and returns the result.
+         *
+         * @see seedu.address.logic.Logic#execute(String)
+         */
+        CommandResult execute(String commandText) throws CommandException, ParseException;
     }
 
     /**
@@ -56,6 +76,12 @@ public class InventoryPanel extends UiPart<Region> {
                 SupplyItemCard updatedCard = new SupplyItemCard(item, getIndex() + 1, increaseHandler.apply(getIndex()),
                         decreaseHandler.apply(getIndex()), changeIncDecHandler.apply(getIndex()));
                 setGraphic(updatedCard.getRoot());
+
+                try {
+                    executeCommand.execute(RefreshStatsCommand.COMMAND_WORD);
+                } catch (CommandException | ParseException e) {
+                    logger.warning("Unable to refresh stats panel!");
+                }
             }
         }
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -14,7 +14,6 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.RefreshStatsCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -206,11 +205,8 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
-
-            if (!commandText.equals(RefreshStatsCommand.COMMAND_WORD)) {
-                logger.info("Result: " + commandResult.getFeedbackToUser());
-                resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-            }
+            logger.info("Result: " + commandResult.getFeedbackToUser());
+            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.RefreshStatsCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -129,7 +130,7 @@ public class MainWindow extends UiPart<Stage> {
         taskListPanelPlaceholder.getChildren().add(taskListPanel.getRoot());
 
         inventoryPanel = new InventoryPanel(logic.getFilteredSupplyItemList(), logic::increaseSupplyItemHandler,
-                logic::decreaseSupplyItemHandler, logic::changeIncDecAmountHandler);
+                logic::decreaseSupplyItemHandler, logic::changeIncDecAmountHandler, this::executeCommand);
         inventoryPanelPlaceholder.getChildren().add(inventoryPanel.getRoot());
 
         statsCard = new StatsCard(logic.getFilteredSupplyItemList(), logic.getFilteredTaskList());
@@ -205,8 +206,11 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
-            logger.info("Result: " + commandResult.getFeedbackToUser());
-            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+
+            if (!commandText.equals(RefreshStatsCommand.COMMAND_WORD)) {
+                logger.info("Result: " + commandResult.getFeedbackToUser());
+                resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            }
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/SupplyItemCard.java
+++ b/src/main/java/seedu/address/ui/SupplyItemCard.java
@@ -23,6 +23,7 @@ public class SupplyItemCard extends UiPart<Region> {
      */
     private static final String FXML = "SupplyItemCard.fxml";
     private static final int MAX_LENGTH = 5;
+    private static final String DEFAULT_TEXT_FIELD_VALUE = "1";
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
      * As a consequence, UI elements' variable names cannot be set to such keywords
@@ -133,8 +134,8 @@ public class SupplyItemCard extends UiPart<Region> {
                 changeIncDecHandler.accept(parsedAmount);
             }
         } catch (NumberFormatException e) {
-            // No changes to value in TextField
-            return;
+            // When TextField value is blank
+            amountInput.setText(DEFAULT_TEXT_FIELD_VALUE);
         }
     }
 }

--- a/src/main/java/seedu/address/ui/SupplyItemCard.java
+++ b/src/main/java/seedu/address/ui/SupplyItemCard.java
@@ -12,6 +12,9 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.logic.commands.RefreshStatsCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.item.SupplyItem;
 
 /**
@@ -36,6 +39,7 @@ public class SupplyItemCard extends UiPart<Region> {
     private final Consumer<Integer> increaseHandler;
     private final Consumer<Integer> decreaseHandler;
     private final Consumer<Integer> changeIncDecHandler;
+    private final InventoryPanel.CommandExecutor executeCommand;
 
     @FXML
     private HBox cardPane;
@@ -62,12 +66,14 @@ public class SupplyItemCard extends UiPart<Region> {
      * Creates a {@code SupplyItemCard} with the given {@code SupplyItem} and index to display.
      */
     public SupplyItemCard(SupplyItem supplyItem, int displayedIndex, Consumer<Integer> increaseHandler,
-                          Consumer<Integer> decreaseHandler, Consumer<Integer> changeIncDecHandler) {
+                          Consumer<Integer> decreaseHandler, Consumer<Integer> changeIncDecHandler,
+                          InventoryPanel.CommandExecutor executeCommand) {
         super(FXML);
         this.supplyItem = supplyItem;
         this.increaseHandler = increaseHandler;
         this.decreaseHandler = decreaseHandler;
         this.changeIncDecHandler = changeIncDecHandler;
+        this.executeCommand = executeCommand;
         cardPane.setStyle(String.format("-fx-border-color:%s ; -fx-border-width: 0 6 0 0;",
                 determineStockHealthColor(supplyItem.getCurrentStock(), supplyItem.getMinStock())));
         id.setText(displayedIndex + ". ");
@@ -103,16 +109,18 @@ public class SupplyItemCard extends UiPart<Region> {
      * Handles the increase of SupplyItem in the Inventory.
      */
     @FXML
-    private void handleIncrease() {
+    private void handleIncrease() throws CommandException, ParseException {
         increaseHandler.accept(supplyItem.getIncDecAmount());
+        executeCommand.execute(RefreshStatsCommand.COMMAND_WORD);
     }
 
     /**
      * Handles the decrease of SupplyItem in the Inventory.
      */
     @FXML
-    private void handleDecrease() {
+    private void handleDecrease() throws CommandException, ParseException {
         decreaseHandler.accept(supplyItem.getIncDecAmount());
+        executeCommand.execute(RefreshStatsCommand.COMMAND_WORD);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/RefreshStatsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshStatsCommandTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalSupplyItems.getTypicalInventory;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class RefreshStatsCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(),
+                getTypicalTaskList(), getTypicalInventory());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(),
+                getTypicalTaskList(), getTypicalInventory());
+    }
+
+    @Test
+    public void execute_listsAreAllUnFiltered_showsEverything() {
+        assertCommandSuccess(new RefreshStatsCommand(), model, RefreshStatsCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -30,6 +30,7 @@ import seedu.address.logic.commands.ListInventoryCommand;
 import seedu.address.logic.commands.ListSupplierCommand;
 import seedu.address.logic.commands.ListTaskCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
+import seedu.address.logic.commands.RefreshStatsCommand;
 import seedu.address.logic.commands.UnMarkTaskCommand;
 import seedu.address.logic.commands.UpdateTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -160,5 +161,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_listInventory() throws ParseException {
         assertTrue(parser.parseCommand(ListInventoryCommand.COMMAND_WORD) instanceof ListInventoryCommand);
+    }
+
+    @Test
+    public void parseCommand_refreshStats() throws ParseException {
+        assertTrue(parser.parseCommand(RefreshStatsCommand.COMMAND_WORD) instanceof RefreshStatsCommand);
     }
 }


### PR DESCRIPTION
Refer to issue #163 

Unit test to test the integrity of data included. (i.e. after refresh, the data is not lost and remains the same)

## NOTE
* We are returning a silent command that does nothing but to refresh the panel.
* `StatsCard` is refreshed on every command. (See [here](https://github.com/AY2223S1-CS2103T-W08-4/tp/blob/94ef106df7e2222af773a79b2170a0a6ed552f07/src/main/java/seedu/address/ui/MainWindow.java#L220))
* Hence, returning a blank state command will refresh the panel.
* `execute()` is passed to the `SupplyItemCard` from the `MainWindow` parent to allow increment / decrement buttons (only) to execute this refresh. This is way cleaner than the previous commit, which refreshes on any action near the `TextField`.