### PR TITLE
UG bugfix for tag related components

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -36,6 +36,10 @@ Salesy is an all-in-one tool for NUS canteen vendors who want to keep track of t
   - The `NAME`, `PHONE`, `PRICE`, `ITEM` and `ADDRESS` fields are compulsory.
   - The `TAG` field is optional.
 
+- For commands that accept tag fields, i.e. `add`, `addTask`, `edit` and `editTask`, multiple tags are allowed but each tag can only contain a single word.
+  - `t/Supplier t/Chicken t/Delivery` is allowed
+  - `t/Supplier for Chicken` is not allowed
+
 - Index numbers in commands, e.g. `delete <supplier index>` are compulsory.
 
 - When multiple similar prefixes are input by the user, e.g. `i/Chicken i/Egg i/Cups`,
@@ -97,16 +101,17 @@ Adds an item of a specified type with the given details
 
 ***Format:***
 
-`add n/NAME p/PHONE(8 digits) pr/PRICE i/ITEM a/ADDRESS [t/SUPPLIER]` **(supplier)**
+`add n/NAME p/PHONE(8 digits) pr/PRICE i/ITEM a/ADDRESS [t/TAG]` **(supplier)**
 
-`addTask d/TASKNAME dl/DEADLINE [t/TAG_NAME]` **(task)**
-
-<div markdown="span" class="alert alert-info">**Note:**
-Multiple entries for `TAG_NAME` are allowed.
-e.g. `addTask d/TASKNAME dl/DEADLINE [t/TAG_NAME1] [t/TAG_NAME2] [t/TAG_NAME3]`
-</div>
+`addTask d/TASKNAME dl/DEADLINE [t/TAG]` **(task)**
 
 `addItem <supplier index> c/CURRENTSTOCK m/MINIMUMSTOCK` (supply item)
+
+<div markdown="span" class="alert alert-info">
+
+**Note:** Tag rules apply for `add` and `addTask`. Refer to [this section](#important-information).
+
+</div>
 
 **Examples:**
 
@@ -206,12 +211,16 @@ Edits a specified item's details
 
 `edit <supplier index> [n/NAME] [p/PHONE] [pr/PRICE] [i/ITEM] [a/ADDRESS] [t/TAG]` (supplier)
 
-`editTask <task index> [d/DESCRIPTION] [dl/DEADLINE] [t/TAGS]` (task)
+`editTask <task index> [d/DESCRIPTION] [dl/DEADLINE] [t/TAG]` (task)
 
-`editStock <item index> c/NEWCURRENTSTOCK` (supply item)
+`editStock <item index> c/CURRENTSTOCK` (supply item)
 
-<div markdown="span" class="alert alert-info">**Note:**
-At least one field has to be edited for the command to execute successfully.
+<div markdown="span" class="alert alert-info">
+
+**Note:** At least one field has to be edited for the command to execute successfully.
+
+Tag rules apply for `edit` and `editTask`. Refer to [this section](#important-information).
+
 </div>
 
 **Examples**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -366,22 +366,22 @@ Clears and deletes all suppliers in Salesy.
 ## Command summary
 
 
-| Action                       | Format                                                      | Examples                                                                           |
-|------------------------------|-------------------------------------------------------------|------------------------------------------------------------------------------------|
-| **clear** (supplier)         | `clear`                                                     | `clear`                                                                            |
-| **list** (supplier)          | `listSuppliers`                                             | `listSuppliers`                                                                    |
-| **add**  (supplier)          | `add n/NAME p/PHONE pr/PRICE i/ITEM a/ADDRESS [t/Supplier]` | `add n/ABC PTE LTD p/67009000 pr/$1.10 i/Egg a/Blk 140 Woodlands Ave 3 t/Supplier` |
-| **delete** (supplier)        | `delete <supplier index>`                                   | `delete 1`                                                                         |
-| **edit**  (supplier)         | `edit <supplier index> <attribute name>/ <new value>`       | `edit 3 pr/NEW PRICE`                                                              |
-| **find**  (supplier)         | `find n/NAMEVALUE` <br>  `find i/ITEMVALUE`                 | `find n/John Cena` <br> `find i/Egg`                                               |
-| **list** (task)              | `listTasks`                                                 | `listTasks`                                                                        |
-| **add** (task)               | `addTask d/DETAILS dl/DEADLINE [t/TAGS]`                    | `addTask d/Restock Eggs dl/2022-12-12 t/Urgent`                                    |
-| **delete** (task)            | `deleteTask <task index>`                                   | `deleteTask 1`                                                                     |
-| **edit** (task)              | `editTask <task index> <attribute name>/ <new value>`       | `editTask 1 dl/2029-12-12`                                                         |
-| **mark**  (task)             | `mark <task index>`                                         | `mark 1`                                                                           |
-| **unmark** (task)            | `unmark <task index>`                                       | `unmark 2`                                                                         |
-| **list** (supply item)       | `listInventory`                                             | `listInventory`                                                                    |
-| **add** (supply item)        | `addItem <supplier index> c/CURRENTSTOCK m/MINIMUMSTOCK`    | `addItem 2 c/10 m/3`                                                               |
-| **delete** (supply item)     | `deleteItem <item index>`                                   | `deleteItem 2`                                                                     |
-| **edit stock** (supply item) | `editStock <item index> c/NEWCURRENTSTOCK`                  | `editStock 2 c/12`                                                                 |
-| **list** (all items)         | `listAll`                                                   | `listAll`                                                                          |                                                    |
+| Action                       | Format                                                   | Examples                                                                           |
+|------------------------------|----------------------------------------------------------|------------------------------------------------------------------------------------|
+| **clear** (supplier)         | `clear`                                                  | `clear`                                                                            |
+| **list** (supplier)          | `listSuppliers`                                          | `listSuppliers`                                                                    |
+| **add**  (supplier)          | `add n/NAME p/PHONE pr/PRICE i/ITEM a/ADDRESS [t/TAG]`   | `add n/ABC PTE LTD p/67009000 pr/$1.10 i/Egg a/Blk 140 Woodlands Ave 3 t/Supplier` |
+| **delete** (supplier)        | `delete <supplier index>`                                | `delete 1`                                                                         |
+| **edit**  (supplier)         | `edit <supplier index> <attribute name>/ <new value>`    | `edit 3 pr/#1.70`                                                                  |
+| **find**  (supplier)         | `find n/NAMEVALUE` <br>  `find i/ITEMVALUE`              | `find n/John Cena` <br> `find i/Egg`                                               |
+| **list** (task)              | `listTasks`                                              | `listTasks`                                                                        |
+| **add** (task)               | `addTask d/DETAILS dl/DEADLINE [t/TAG]`                  | `addTask d/Restock Eggs dl/2022-12-12 t/Urgent`                                    |
+| **delete** (task)            | `deleteTask <task index>`                                | `deleteTask 1`                                                                     |
+| **edit** (task)              | `editTask <task index> <attribute name>/ <new value>`    | `editTask 1 dl/2029-12-12`                                                         |
+| **mark**  (task)             | `mark <task index>`                                      | `mark 1`                                                                           |
+| **unmark** (task)            | `unmark <task index>`                                    | `unmark 2`                                                                         |
+| **list** (supply item)       | `listInventory`                                          | `listInventory`                                                                    |
+| **add** (supply item)        | `addItem <supplier index> c/CURRENTSTOCK m/MINIMUMSTOCK` | `addItem 2 c/10 m/3`                                                               |
+| **delete** (supply item)     | `deleteItem <item index>`                                | `deleteItem 2`                                                                     |
+| **edit stock** (supply item) | `editStock <item index> c/CURRENTSTOCK`                  | `editStock 2 c/12`                                                                 |
+| **list** (all items)         | `listAll`                                                | `listAll`                                                                          |                                                    |

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric and contain only a single word";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;


### PR DESCRIPTION
Plurality of the word `TAG` in command examples is now standardised
Additional information added to specify that multi-word tags are not allowed
Input field for `editStock` updated to match `addItem`

Resolves #187 and resolves #227.
